### PR TITLE
fix: Sync binary version with package.json dynamically

### DIFF
--- a/qudag-npm/src/binary-manager.ts
+++ b/qudag-npm/src/binary-manager.ts
@@ -8,8 +8,9 @@ import { createWriteStream } from 'fs';
 import { pipeline } from 'stream/promises';
 import { platform as getPlatform, arch as getArch } from 'os';
 
-// Binary version - should match the Rust crate version
-const BINARY_VERSION = 'v1.0.2';
+// Binary version - dynamically read from package.json to stay in sync
+import { version as PKG_VERSION } from '../package.json';
+const BINARY_VERSION = `v${PKG_VERSION}`;
 const GITHUB_REPO = 'ruvnet/QuDAG';
 
 // Platform mapping


### PR DESCRIPTION
## Summary
- Fixed binary-manager.ts to dynamically read version from package.json instead of hardcoding
- This ensures npm package version stays in sync with GitHub releases
- Prevents "binary not found" errors when package version is bumped

## Problem
The npm package was at version 1.2.1 but `binary-manager.ts` had `BINARY_VERSION = 'v1.0.2'` hardcoded, causing download failures for platforms like `aarch64-apple-darwin`.

## Solution
```typescript
// Before (hardcoded, out of sync):
const BINARY_VERSION = 'v1.0.2';

// After (dynamic):
import { version as PKG_VERSION } from '../package.json';
const BINARY_VERSION = `v${PKG_VERSION}`;
```

## Related
- Issue #10: Request for v1.2.1 release with darwin-arm64 binaries

## Test plan
- [x] Verify TypeScript compiles with `resolveJsonModule: true` (already enabled in tsconfig.json)
- [ ] Test binary download after next release is published

🤖 Generated with [Claude Code](https://claude.com/claude-code)
